### PR TITLE
chore: add more os to CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
         node: [18, 20]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add Ubuntu 24.04 and Windows 2025 to the CI matrix