### PR TITLE
ci: use tags for immutable GitHub Actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: yarn


### PR DESCRIPTION
## Summary by Sourcery

Use version tags for GitHub Actions in the commitlint CI workflow instead of commit SHAs to improve immutability and maintainability.

CI:
- Pin actions/checkout to v4 instead of a specific commit SHA
- Pin actions/setup-node to v4 instead of a specific commit SHA