### PR TITLE
docs: add setup guide for bun

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -89,6 +89,19 @@ npm pkg set scripts.commitlint="commitlint --edit"
 echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```
 
+== bun
+
+```sh
+bun add --dev husky
+
+bunx husky install
+
+# Add commit message linting to commit-msg hook
+echo "bunx commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "bunx commitlint --edit `$1" > .husky/commit-msg
+```
+
 == deno
 
 ```sh


### PR DESCRIPTION
## Summary by Sourcery

Add a new ‘bun’ section to the local setup guide for installing Husky and configuring a commitlint hook

Documentation:
- Introduce a ‘bun’ guide showing how to install Husky and initialize its hooks
- Show how to add a commitlint hook with bunx, including a Windows-specific command variation