### PR TITLE
docs: remove leftover double hyphen in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -34,7 +34,7 @@ npm install --save-dev husky
 npx husky install
 
 # Add commit message linting to commit-msg hook
-echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+echo "npx --no commitlint --edit \$1" > .husky/commit-msg
 # Windows users should use ` to escape dollar signs
 echo "npx --no commitlint --edit `$1" > .husky/commit-msg
 ```


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix the commit-msg hook example by eliminating the extra hyphen in the npx command