### PR TITLE
docs: add double hyphen to npm husky command in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -36,7 +36,7 @@ npx husky install
 # Add commit message linting to commit-msg hook
 echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
 # Windows users should use ` to escape dollar signs
-echo "npx --no commitlint --edit `$1" > .husky/commit-msg
+echo "npx --no -- commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add missing `--` flag to the npx commitlint command in the husky commit-msg hook example in the local-setup guide