### PR TITLE
docs: add `husky init` command to bun in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -103,6 +103,9 @@ echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```sh
 bun add --dev husky
 
+# husky@v9
+bunx husky init
+# husky@v8 or lower
 bunx husky install
 
 # Add commit message linting to commit-msg hook


### PR DESCRIPTION
## Summary by Sourcery

Update local setup guide to include the `husky init` command for v9 and clarify installation commands for lower versions.

Documentation:
- Add `bunx husky init` step for Husky v9 in the local-setup guide
- Clarify using `bunx husky install` for Husky v8 or lower versions