### PR TITLE
docs: version up @commitlint/cli in CLI section

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@
 ```sh
 ❯ npx commitlint --help
 
-@commitlint/cli@19.5.0 - Lint your commit messages
+@commitlint/cli@19.8.1 - Lint your commit messages
 
 [input] reads from stdin if --edit, --env, --from and --to are omitted
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump displayed @commitlint/cli version from 19.5.0 to 19.8.1 in the CLI section of the docs