### PR TITLE
docs: update cosmiconfig url to v9.0.0

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,7 +25,7 @@ The file is expected
 - export a configuration object
 - adhere to the schema outlined below
 
-Configuration files are resolved using [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig/tree/v8.2.0).
+Configuration files are resolved using [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig/tree/v9.0.0).
 
 ## Config via `package.json`
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the cosmiconfig URL in the configuration reference to v9.0.0 version.