### PR TITLE
docs: version up @commitlint/cli in CLI section

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,9 +1,14 @@
+<script setup>
+  import packageJson from "../../@commitlint/cli/package.json"
+  const commitlintVersion = packageJson.version
+</script>
+
 # CLI
 
-```sh
+```sh-vue
 ❯ npx commitlint --help
 
-@commitlint/cli@19.5.0 - Lint your commit messages
+@commitlint/cli@{{ commitlintVersion }} - Lint your commit messages
 
 [input] reads from stdin if --edit, --env, --from and --to are omitted
 


### PR DESCRIPTION
## Summary by Sourcery

Integrate dynamic version display for the commitlint CLI in the reference docs and adjust the code block syntax

Documentation:
- Import the CLI’s package.json in a Vue script setup to inject the current version into the docs
- Update the CLI example code fence from `sh` to `sh-vue` and replace the hardcoded version with the dynamic value