### PR TITLE
Add multi-manager examples and code groups to guides

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -147,9 +147,29 @@ Info about git hooks can be found on [Git documentation](https://git-scm.com/boo
 
 For a first simple usage test of commitlint you can do the following:
 
-```bash
+::: code-group
+
+```sh [npm]
 npx commitlint --from HEAD~1 --to HEAD --verbose
 ```
+
+```sh [yarn]
+yarn commitlint --from HEAD~1 --to HEAD --verbose
+```
+
+```sh [pnpm]
+pnpm dlx commitlint --from HEAD~1 --to HEAD --verbose
+```
+
+```sh [bun]
+bunx commitlint --from HEAD~1 --to HEAD --verbose
+```
+
+```sh [deno]
+deno task --eval commitlint --from HEAD~1 --to HEAD --verbose
+```
+
+:::
 
 This will check your last commit and return an error if invalid or a positive output if valid.
 

--- a/docs/guides/use-prompt.md
+++ b/docs/guides/use-prompt.md
@@ -12,17 +12,61 @@
 
 2. Create a package.json if needed
 
-   ```sh
+   ::: code-group
+
+   ```sh [npm]
    npm init
    ```
 
+   ```sh [yarn]
+   yarn init
+   ```
+
+   ```sh [pnpm]
+   pnpm init
+   ```
+
+   ```sh [bun]
+   bun init
+   ```
+
+   :::
+
 3. Install and configure if needed
 
-   ```sh
+   ::: code-group
+
+   ```sh [npm]
    npm install --save-dev @commitlint/cli @commitlint/config-conventional @commitlint/prompt-cli
 
    echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
    ```
+
+   ```sh [yarn]
+   yarn add --dev @commitlint/cli @commitlint/config-conventional @commitlint/prompt-cli
+
+   echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+   ```
+
+   ```sh [pnpm]
+   pnpm add --save-dev @commitlint/cli @commitlint/config-conventional @commitlint/prompt-cli
+
+   echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+   ```
+
+   ```sh [bun]
+   bun add --dev @commitlint/cli @commitlint/config-conventional @commitlint/prompt-cli
+
+   echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+   ```
+
+   ```sh [deno]
+   deno add --dev npm:@commitlint/cli npm:@commitlint/config-conventional npm:@commitlint/prompt-cli
+
+   echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+   ```
+
+   :::
 
 ## Provide a shortcut
 
@@ -38,10 +82,34 @@ To make prompt-cli easy to use, add a npm run-script to your `package.json`
 
 Test the prompt by executing
 
-```bash
+::: code-group
+
+```sh [npm]
 git add .
 npm run commit
 ```
+
+```sh [yarn]
+git add .
+yarn commit
+```
+
+```sh [pnpm]
+git add .
+pnpm commit
+```
+
+```sh [bun]
+git add .
+bun commit
+```
+
+```sh [deno]
+git add .
+deno task commit
+```
+
+:::
 
 ## An alternative to `@commitlint/prompt-cli`: commitizen
 


### PR DESCRIPTION
## Summary by Sourcery

Group shell command examples into code-group blocks and add Yarn, pnpm, Bun, and Deno variants across the use-prompt and local-setup guides.

Documentation:
- Wrap initialization, installation, commit, and linting commands in code-group sections for npm, Yarn, pnpm, Bun, and Deno in use-prompt.md
- Add corresponding code-group examples for running commitlint and testing hooks in local-setup.md with npm, Yarn, pnpm, Bun, and Deno