### PR TITLE
docs: update commitlint test code

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -158,11 +158,11 @@ yarn commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [pnpm]
-pnpm dlx commitlint --from HEAD~1 --to HEAD --verbose
+pnpm commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [bun]
-bunx commitlint --from HEAD~1 --to HEAD --verbose
+bun commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [deno]


### PR DESCRIPTION
## Summary by Sourcery

Update commitlint invocation instructions in the local setup guide

Documentation:
- Use 'pnpm commitlint' instead of 'pnpm dlx commitlint' in the pnpm example
- Use 'bun commitlint' instead of 'bunx commitlint' in the bun example